### PR TITLE
Corrige erro ao criar devolução de compra

### DIFF
--- a/l10n_br_account_product/wizard/l10n_br_refund.py
+++ b/l10n_br_account_product/wizard/l10n_br_refund.py
@@ -80,7 +80,10 @@ class account_invoice_refund(orm.TransientModel):
                                      invoice.company_id.id, send_line.product_id.id, line_fiscal_category_id,
                                      send_line.account_id.id, context)
                     line_onchange['value']['fiscal_category_id'] = line_fiscal_category_id
-
+                    if 'invoice_line_tax_id' in line_onchange['value']:
+                        taxes = line_onchange['value']['invoice_line_tax_id']
+                        line_onchange['value']['invoice_line_tax_id'] = [[6, 0, taxes]]
+                        
                     line_obj.write(cr, uid, line_ids[idx],line_onchange['value'],context)
                 inv_obj.write(cr, uid, [invoice.id], onchange['value'], context=context)
             return res


### PR DESCRIPTION
Corrige erro no reembolso de venda:

File "/home/danimar/projetos/odoo/l10n-brazil/l10n_br_account_product/wizard/l10n_br_refund.py", line 87, in compute_refund
line_obj.write(cr, uid, line_ids[idx],line_onchange['value'],context)
File "/home/danimar/projetos/odoo/odoo-8/openerp/api.py", line 241, in wrapper
return old_api(self, args, *kwargs)
File "/home/danimar/projetos/odoo/l10n-brazil/l10n_br_account_product/account_invoice.py", line 839, in write
vals.update(self.validate_taxes(cr, uid, vals, context))
File "/home/danimar/projetos/odoo/odoo-8/openerp/api.py", line 241, in wrapper
return old_api(self, args, *kwargs)
File "/home/danimar/projetos/odoo/l10n-brazil/l10n_br_account_product/account_invoice.py", line 785, in validate_taxes
cr, uid, values.get('invoice_line_tax_id')[0][2])
TypeError: 'int' object has no attribute '__getitem'
