### PR TITLE
Rewrite module to V8.0 and add the remote search to ViaCEP.com when a ZIP Code is not found in the database

### DIFF
--- a/l10n_br_base/res_company_view.xml
+++ b/l10n_br_base/res_company_view.xml
@@ -13,7 +13,7 @@
 				<field name="zip" position="replace"/>
 				<field name="street" position="replace">
 					<field name="zip" placeholder="Cep" style="width:50%;" />
-					<field name="street"/>
+					<field name="street" placeholder="Logradouro"/>
 					<field name="number" placeholder="número"/>
 					<field name="street2" placeholder="complemento"/>
 					<field name="district" placeholder="bairro"/>

--- a/l10n_br_base/res_partner_view.xml
+++ b/l10n_br_base/res_partner_view.xml
@@ -51,7 +51,7 @@
                 		<field name="zip" position="replace"/>
 				<field name="street" position="replace">
 					<field name="zip" placeholder="Cep"/>
-					<field name="street" placeholder="Logadouro"/>
+					<field name="street" placeholder="Logradouro"/>
 					<field name="number" placeholder="numero" />
 					<field name="district" placeholder="bairro" />
 				</field>


### PR DESCRIPTION
This pull request is to completely adjust this module to V8.0 and make it search in www.viacep.com when a ZIP code is not found in the database, when that happens the code loads the new ZIP Code into the Database to be easily used in the future.

This allows the module to not need to have a full ZIP Code table loaded which would increase the download time and add the overhead to keep the database up-to-date.

It has one issue, I couldn't make a wizard to choose between a list of ZIP Codes when more than 1 is found by any reason (when searching by the ZIP Code or by Address), in that case I added a warning message for the user to be more specific, this needs to be complete in the future.
